### PR TITLE
ReadPointer only reinterpret_cast if not doing pointer arith, fixes #1

### DIFF
--- a/src/binding.cc
+++ b/src/binding.cc
@@ -227,7 +227,14 @@ Handle<Value> ReadPointer(const Arguments& args) {
           String::New("readPointer: Cannot read from NULL pointer")));
   }
 
-  char *val = *reinterpret_cast<char **>(ptr);
+  char *val;
+
+  if (offset == 0) {
+    val = *reinterpret_cast<char **>(ptr);
+  } else {
+    val = ptr;
+  }
+
   Buffer *rtn_buf = Buffer::New(val, size, read_pointer_cb, NULL);
   return scope.Close(rtn_buf->handle_);
 }


### PR DESCRIPTION
When doing the reinterpret_cast of the offset it changed the address of the new pointer, causing all sorts of havoc

```
ReadPointer 0x101816b00 + 0 -- 0x101816b00
Reinterpret_Cast 0x100a1a070
track 0 address 0x100a1a070
ReadPointer 0x101816b00 + 28 -- 0x101816b1c
Reinterpret_Cast 0xb7150000000001
track 1 address 0xb7150000000000
```

This change only does the reinterpret_cast if ReadPointer is called with a 0 offset

Fixes #1
