### PR TITLE
Update nan to ^1.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "bindings": "~1.2.0",
     "debug": "2",
-    "nan": "~1.7.0"
+    "nan": "^1.8.0"
   },
   "devDependencies": {
     "dox": "0.4.4",


### PR DESCRIPTION
ref failed to build using Electron 0.25.2 (io.js v1.6.3) because of an old version of nan. This should fix that.
Minor version increments for nan shouldn't be breaking, so caret is used.