### PR TITLE
NAN 2.0 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@ npm-debug.log
 
 # ignore root-level single-letter file dev files
 ?.js
+
+#IDE
+/.idea
+.kdev*

--- a/package.json
+++ b/package.json
@@ -29,16 +29,16 @@
     "test": "mocha -gc --reporter spec"
   },
   "dependencies": {
-    "bindings": "~1.2.0",
+    "bindings": "1",
     "debug": "2",
-    "nan": "~1.8.4"
+    "nan": "2"
   },
   "devDependencies": {
     "dox": "0.4.4",
     "highlight.js": "1",
-    "jade": "0.35.0",
-    "marked": "0.3.2",
+    "jade": "^0.35.0",
+    "marked": "^0.3.2",
     "mocha": "*",
-    "weak": "0.3.2"
+    "weak": "0"
   }
 }


### PR DESCRIPTION
NAN 2.0 support implemented, all test passed.

However it won't install under io.js 3.0 as a root (development project), because its weak (dev)dependency is still missing its NAN 2.0 support.

I think you should merge it ASAP, because node-ffi NAN 2.0 PR is blocked because of that. Unfortunately I don't have time to update weak.