### PR TITLE
Reduce cost by pushing message assembly down.

### DIFF
--- a/lib/ref.js
+++ b/lib/ref.js
@@ -379,16 +379,18 @@ exports.coerceType = function coerceType (type) {
       // allow string names to be passed in
       rtn = exports.types[rtn]
       if (refCount > 0) {
-        assert(rtn && 'size' in rtn && 'indirection' in rtn
-            , 'could not determine a proper "type" from: ' + JSON.stringify(type))
+        if (!(rtn && 'size' in rtn && 'indirection' in rtn)) {
+          assert(false, 'could not determine a proper "type" from: ' + JSON.stringify(type))
+        }
         for (var i = 0; i < refCount; i++) {
           rtn = exports.refType(rtn)
         }
       }
     }
   }
-  assert(rtn && 'size' in rtn && 'indirection' in rtn
-      , 'could not determine a proper "type" from: ' + JSON.stringify(type))
+  if (!(rtn && 'size' in rtn && 'indirection' in rtn)) {
+    assert(false, 'could not determine a proper "type" from: ' + JSON.stringify(type))
+  }
   return rtn
 }
 


### PR DESCRIPTION
JSON.stringify can be expensive, so only take the hit when the assert will throw.

Fixes TooTallNate/ref#38.