### PR TITLE
Possible fix for node-ffi issue #244

### DIFF
--- a/src/binding.cc
+++ b/src/binding.cc
@@ -143,6 +143,7 @@ void wrap_pointer_cb(char *data, void *hint) {
 
 inline Local<Value> WrapPointer(char *ptr, size_t length) {
   Nan::EscapableHandleScope scope;
+  if (ptr == NULL) length = 0;
   return scope.Escape(Nan::NewBuffer(ptr, length, wrap_pointer_cb, NULL).ToLocalChecked());
 }
 

--- a/test/pointer.js
+++ b/test/pointer.js
@@ -51,6 +51,13 @@ describe('pointer', function () {
     })
   })
 
+  it('should return a 0-length Buffer when reading a NULL pointer', function () {
+    var buf = new Buffer(ref.sizeof.pointer)
+    ref.writePointer(buf, 0, ref.NULL)
+    var out = ref.readPointer(buf, 0, 100)
+    assert.strictEqual(out.length, 0)
+  })
+
   describe('offset', function () {
 
     it('should read two pointers next to each other in memory', function () {


### PR DESCRIPTION
Not sure if this will fix all cases, but causes my unit tests to pass instead of erroring with `Assertion '(obj_data) != (nullptr)' failed` after updating to node.js 4.