### PR TITLE
Replaced deprecated call to ForceSet with Nan::ForceSet

### DIFF
--- a/src/binding.cc
+++ b/src/binding.cc
@@ -640,8 +640,8 @@ NAN_MODULE_INIT(init) {
   // exports
   target->Set(Nan::New<v8::String>("sizeof").ToLocalChecked(), smap);
   target->Set(Nan::New<v8::String>("alignof").ToLocalChecked(), amap);
-  target->ForceSet(Nan::New<v8::String>("endianness").ToLocalChecked(), Nan::New<v8::String>(CheckEndianness()).ToLocalChecked(), static_cast<PropertyAttribute>(ReadOnly|DontDelete));
-  target->ForceSet(Nan::New<v8::String>("NULL").ToLocalChecked(), WrapNullPointer(), static_cast<PropertyAttribute>(ReadOnly|DontDelete));
+  Nan::ForceSet(target, Nan::New<v8::String>("endianness").ToLocalChecked(), Nan::New<v8::String>(CheckEndianness()).ToLocalChecked(), static_cast<PropertyAttribute>(ReadOnly|DontDelete));
+  Nan::ForceSet(target, Nan::New<v8::String>("NULL").ToLocalChecked(), WrapNullPointer(), static_cast<PropertyAttribute>(ReadOnly|DontDelete));
   Nan::SetMethod(target, "address", Address);
   Nan::SetMethod(target, "hexAddress", HexAddress);
   Nan::SetMethod(target, "isNull", IsNull);


### PR DESCRIPTION
Hi, 

when I switched to node 6.9.x I got some deprecation warnings when ref was compiled.
I tried my hand at fixing them, and as far as I can see, the unit tests are still running and the deprecation warnings are gone.

Cheers,
Michael