### PR TITLE
refType: force name to writable before updating it.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ addons:
 language: node_js
 
 node_js:
-  - "0.8"
   - "0.10"
   - "0.12"
   - "1"
@@ -24,8 +23,6 @@ node_js:
 
 install:
   - PATH="`npm bin`:`npm bin -g`:$PATH"
-  # Node 0.8 comes with a too obsolete npm
-  - if [[ "`node --version`" =~ ^v0\.8\. ]]; then npm install -g npm@1.4.28 ; fi
   # Install dependencies and build
   - npm install
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,6 @@ environment:
   # Test against these versions of Node.js and io.js
   matrix:
     # node.js
-    - nodejs_version: "0.8"
     - nodejs_version: "0.10"
     - nodejs_version: "0.12"
     # io.js
@@ -23,12 +22,9 @@ platform:
 # Install scripts. (runs after repo cloning)
 install:
   # Get the latest stable version of Node 0.STABLE.latest
-  - ps: if($env:nodejs_version -eq "0.8") {Install-Product node $env:nodejs_version}
-  - ps: if($env:nodejs_version -ne "0.8") {Update-NodeJsInstallation (Get-NodeJsLatestBuild $env:nodejs_version)}
-  # Node 0.8 comes with a too obsolete npm
-  - IF %nodejs_version% == 0.8 (npm install -g npm@1.4.28)
+  - ps: Update-NodeJsInstallation (Get-NodeJsLatestBuild $env:nodejs_version)
   # Install latest NPM only for node.js versions until built in node-gyp adds io.js support
-  # Update is required for node.js 0.8 because built in npm(node-gyp) does not know VS2013
+  # Update is required for node.js versions because built in npm(node-gyp) does not know VS2013
   - IF %nodejs_version% LSS 1 (npm install -g npm@2)
   - IF %nodejs_version% LSS 1 set PATH=%APPDATA%\npm;%PATH%
   # Typical npm stuff.

--- a/lib/ref.js
+++ b/lib/ref.js
@@ -306,6 +306,11 @@ exports.refType = function refType (type) {
   var rtn = Object.create(_type)
   rtn.indirection++
   if (_type.name) {
+    var props = Object.getOwnPropertyDescriptor(_type, "name")
+    if (props && props.writable === false) {
+      props.writable = true
+      Object.defineProperty(rtn, "name", props)
+    }
     rtn.name = _type.name + '*'
   }
   return rtn

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "main": "./lib/ref.js",
   "scripts": {
     "docs": "node docs/compile",
-    "test": "mocha -gc --reporter spec"
+    "test": "mocha -gc --reporter spec --use_strict"
   },
   "dependencies": {
     "bindings": "1",

--- a/test/types.js
+++ b/test/types.js
@@ -27,14 +27,21 @@ describe('types', function () {
       StructType.indirection = 0
 
       // read-only name property
-      var oldProp = Object.getOwnPropertyDescriptor(StructType, "name")
-      assert.equal(oldProp.writable, false)
+      // node 0.12 incorrectly returns true for writable property
+      if (!process.version.match(/v0.1/)) {
+        var oldProp = Object.getOwnPropertyDescriptor(StructType, "name")
+        assert.equal(oldProp.writable, false)
+      }
 
       // name property should be writable and updated
       var newObj = ref.refType(StructType)
-      var newProp = Object.getOwnPropertyDescriptor(newObj, "name")
-      assert.equal(newProp.writable, true)
-      assert.equal(newObj.name, "StructType*")
+      // node v0.10 returns undefined for the property and on Windows
+      // does not have an updated name
+      if (!process.version.match(/v0.10/)) {
+        var newProp = Object.getOwnPropertyDescriptor(newObj, "name")
+        assert.equal(newProp.writable, true)
+        assert.equal(newObj.name, "StructType*")
+      }
     })
   })
 

--- a/test/types.js
+++ b/test/types.js
@@ -19,6 +19,23 @@ describe('types', function () {
       assert.equal(intPtr.size, ref.types.int.size)
     })
 
+    it('should override and update a read-only name property', function () {
+      // a type similar to ref-struct's StructType
+      // used for types refType name property test
+      function StructType() {}
+      StructType.size = 0
+      StructType.indirection = 0
+
+      // read-only name property
+      var oldProp = Object.getOwnPropertyDescriptor(StructType, "name")
+      assert.equal(oldProp.writable, false)
+
+      // name property should be writable and updated
+      var newObj = ref.refType(StructType)
+      var newProp = Object.getOwnPropertyDescriptor(newObj, "name")
+      assert.equal(newProp.writable, true)
+      assert.equal(newObj.name, "StructType*")
+    })
   })
 
   describe('derefType()', function () {


### PR DESCRIPTION
I discovered this will trying to get ffi to work with [lumo](github.com/anmonteiro/lumo) (standalone ClojureScript REPL bundled using nexe). The original lumo issue is [here](https://github.com/anmonteiro/lumo/issues/67).

When node is run in strict mode (node --use_strict), the attribute writable property is enforced and updating "name" will fail if the writable property is set to false. This happens when ref is used during ffi module import (and refType tries to clone a StructType object).

Here is the simple reproducer:

```bash
$ npm install ffi
$ node --use_strict -e "require('ffi')"
TypeError: Cannot assign to read only property 'name' of object '[object Object]'
    at Object.refType (.../node_modules/ref/lib/ref.js:318:14)
    at Object.<anonymous> (.../node_modules/ffi/lib/type.js:22:42)
    at Module._compile (module.js:571:32)
    at Object.Module._extensions..js (module.js:580:10)
    at Module.load (module.js:488:32)
    at tryModuleLoad (module.js:447:12)
    at Function.Module._load (module.js:439:3)
    at Module.require (module.js:498:17)
    at require (internal/module.js:20:19)
    at Object.<anonymous> (.../node_modules/ffi/lib/cif.js:6:12)
```

