### PR TITLE
Avoid problems when required twice

### DIFF
--- a/lib/ref.js
+++ b/lib/ref.js
@@ -4,6 +4,13 @@ var debug = require('debug')('ref')
 
 exports = module.exports = require('bindings')('binding')
 
+if (exports._initialized) {
+  // Avoid problems when required twice due to test runners like jest
+  return;
+}
+
+exports._initialized = true;
+
 /**
  * A `Buffer` that references the C NULL pointer. That is, its memory address
  * points to 0. Its `length` is 0 because accessing any data from this buffer


### PR DESCRIPTION
It's possible due to test runners like jest playing with the node runtime object.

The native module can't be required twice but the javascript one can. As the javascript one return a mutated version of the native one it create problems :

```js
exports._writePointer = exports.writePointer

exports.writePointer = function writePointer (buf, offset, ptr) {
  debug('writing pointer to buffer', buf, offset, ptr)
  exports._writePointer(buf, offset, ptr)
  exports._attach(buf, ptr)
}
```

After 2+ executions of this code `writePointer` would call itself and produce a stack overflow exception.

*Additional info*
* The problematic function in jest is : [resetModules](https://facebook.github.io/jest/docs/jest-object.html#jestresetmodules).
* I encountered the problem in the context of this PR to yarn : https://github.com/yarnpkg/yarn/pull/2960