### PR TITLE
don't fail in node < 6.9.1

### DIFF
--- a/lib/ref.js
+++ b/lib/ref.js
@@ -1414,7 +1414,13 @@ Buffer.prototype.reinterpretUntilZeros = function reinterpretUntilZeros (size, o
  */
 
 var inspectSym = inspect.custom || 'inspect'
-Buffer.prototype[inspectSym] = overwriteInspect(Buffer.prototype[inspectSym])
+/**
+ * in node 6.91, inspect.custom does not give a correct value; so in this case, don't torch the whole process.
+ * fixed in >6.9.2
+ */
+if (Buffer.prototype[inspectSym]){
+  Buffer.prototype[inspectSym] = overwriteInspect(Buffer.prototype[inspectSym])
+}
 
 
 // does SlowBuffer inherit from Buffer? (node >= v0.7.9)
@@ -1448,7 +1454,13 @@ if (!(exports.NULL instanceof Buffer)) {
   SlowBuffer.prototype.writeInt64LE = Buffer.prototype.writeInt64LE
   SlowBuffer.prototype.readUInt64LE = Buffer.prototype.readUInt64LE
   SlowBuffer.prototype.writeUInt64LE = Buffer.prototype.writeUInt64LE
-  SlowBuffer.prototype[inspectSym] = overwriteInspect(SlowBuffer.prototype[inspectSym])
+/**
+ * in node 6.9.1, inspect.custom does not give a correct value; so in this case, don't torch the whole process.
+ * fixed in >6.9.2
+ */
+  if (SlowBuffer.prototype[inspectSym]){
+    SlowBuffer.prototype[inspectSym] = overwriteInspect(SlowBuffer.prototype[inspectSym])
+  }
 }
 
 function overwriteInspect (inspect) {


### PR DESCRIPTION
check Buffer.prototype[inspectSym] and SlowBuffer.prototype[inspectSym] are valid before trying to replace them.
This basically just disables the modification to inspection for node versions which supply an invalid inspect.custom, but at least it no longer kills the whole application.