### PR TITLE
fix readPointer example

### DIFF
--- a/lib/ref.js
+++ b/lib/ref.js
@@ -94,10 +94,10 @@ exports = module.exports = require('bindings')('binding')
  *
  * ```
  * var buf = new Buffer('hello world');
- * var pointer = ref.alloc('pointer');
+ * var pointer = ref.alloc('pointer', buf);
  *
  * var buf2 = ref.readPointer(pointer, 0, buf.length);
- * console.log(buf.toString());
+ * console.log(buf2.toString());
  * 'hello world'
  * ```
  *


### PR DESCRIPTION
The `readPointer` example was a bit mixed up: it wasn't really doing
anything. I changed it to be what (I think) was intended. I now see:

> var buf = new Buffer('hello world');
undefined
> var pointer = ref.alloc('pointer', buf);
undefined
> var buf2 = ref.readPointer(pointer, 0, buf.length);
undefined
> buf2.toString()
'hello world'
