### PR TITLE
Updated nan to fix Node 10 install issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "bindings": "1",
     "debug": "4",
-    "nan": "2"
+    "nan": "2.12.1"
   },
   "devDependencies": {
     "dox": "0.9.0",


### PR DESCRIPTION
Nan error:

```
../../nan/nan_maybe_43_inl.h:112:15: error: no member named 'ForceSet' in 'v8::Object'

npm ERR! Failed at the ref@1.3.5 install script.
```

Fixed in 2.12.1.