### PR TITLE
Removed deprecated V8 methods warnings for node 10/11

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "highlight.js": "1",
     "jade": "1",
     "marked": "0.5.2",
-    "mocha": "*",
+    "mocha": "5.0.0",
     "weak": "1"
   }
 }

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -219,7 +219,7 @@ NAN_METHOD(WriteObject) {
   Nan::Persistent<Object>* pptr = reinterpret_cast<Nan::Persistent<Object>*>(ptr);
   Local<Object> val = info[2].As<Object>();
 
-  bool persistent = info[3]->BooleanValue();
+  bool persistent = Nan::To<bool>(info[3]).FromJust();
   if (persistent) {
       (*pptr).Reset(val);
   } else {
@@ -250,7 +250,8 @@ NAN_METHOD(ReadPointer) {
 
   int64_t offset = GetInt64(info[1]);
   char *ptr = Buffer::Data(buf.As<Object>()) + offset;
-  size_t size = info[2]->Uint32Value();
+
+  size_t size = Nan::To<uint32_t>(info[2]).FromJust();;
 
   if (ptr == NULL) {
     return Nan::ThrowError("readPointer: Cannot read from NULL pointer");
@@ -357,8 +358,7 @@ NAN_METHOD(WriteInt64) {
   } else if (in->IsString()) {
     char *endptr, *str;
     int base = 0;
-    String::Utf8Value _str(in);
-    str = *_str;
+    str = *Nan::Utf8String(in);
 
     errno = 0;     /* To distinguish success/failure after call */
     val = strtoll(str, &endptr, base);
@@ -444,8 +444,7 @@ NAN_METHOD(WriteUInt64) {
   } else if (in->IsString()) {
     char *endptr, *str;
     int base = 0;
-    String::Utf8Value _str(in);
-    str = *_str;
+    str = *Nan::Utf8String(in);
 
     errno = 0;     /* To distinguish success/failure after call */
     val = strtoull(str, &endptr, base);
@@ -518,7 +517,7 @@ NAN_METHOD(ReinterpretBuffer) {
     return Nan::ThrowError("reinterpret: Cannot reinterpret from NULL pointer");
   }
 
-  size_t size = info[1]->Uint32Value();
+  size_t size = Nan::To<uint32_t>(info[1]).FromJust();;
 
   info.GetReturnValue().Set(WrapPointer(ptr, size));
 }
@@ -547,7 +546,7 @@ NAN_METHOD(ReinterpretBufferUntilZeros) {
     return Nan::ThrowError("reinterpretUntilZeros: Cannot reinterpret from NULL pointer");
   }
 
-  uint32_t numZeros = info[1]->Uint32Value();
+  uint32_t numZeros = Nan::To<uint32_t>(info[1]).FromJust();
   uint32_t i = 0;
   size_t size = 0;
   bool end = false;
@@ -642,8 +641,8 @@ NAN_MODULE_INIT(init) {
   // exports
   target->Set(Nan::New<v8::String>("sizeof").ToLocalChecked(), smap);
   target->Set(Nan::New<v8::String>("alignof").ToLocalChecked(), amap);
-  Nan::ForceSet(target, Nan::New<v8::String>("endianness").ToLocalChecked(), Nan::New<v8::String>(CheckEndianness()).ToLocalChecked(), static_cast<PropertyAttribute>(ReadOnly|DontDelete));
-  Nan::ForceSet(target, Nan::New<v8::String>("NULL").ToLocalChecked(), WrapNullPointer(), static_cast<PropertyAttribute>(ReadOnly|DontDelete));
+  Nan::DefineOwnProperty(target, Nan::New<v8::String>("endianness").ToLocalChecked(), Nan::New<v8::String>(CheckEndianness()).ToLocalChecked(), static_cast<PropertyAttribute>(ReadOnly|DontDelete));
+  Nan::DefineOwnProperty(target, Nan::New<v8::String>("NULL").ToLocalChecked(), WrapNullPointer(), static_cast<PropertyAttribute>(ReadOnly|DontDelete));
   Nan::SetMethod(target, "address", Address);
   Nan::SetMethod(target, "hexAddress", HexAddress);
   Nan::SetMethod(target, "isNull", IsNull);


### PR DESCRIPTION
Used node versions: 10.11.0 and 11.9.0